### PR TITLE
auto-define-os

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,14 +34,6 @@ add_required_dependency("eigen-quadprog")
 add_required_dependency("dynamic-graph >= 3.0.0")
 add_required_dependency("dynamic-graph-python >= 3.0.0")
 
-####################################
-# Define the OS to be used locally #
-####################################
-
-# This macro sets the C++ preprocessor flags "XENOMAI", "RT_PREEMPT", or
-# "UBUNTU" according to the current operating system.
-define_os()
-
 ######################################################
 # define the include directory of all ${CATKIN_PKGS} #
 ######################################################


### PR DESCRIPTION
# What changed?

I updated the CMake Macro search_for_cereal to search_for_cereal_required in order to make sure this dependency is not missing.

# Merge after the following merge:

machines-in-motion/mpi_cmake_modules#2