### PR TITLE
Mnaveau/remove scipy from sliders subgraph

### DIFF
--- a/demos/demo_filter.py
+++ b/demos/demo_filter.py
@@ -23,22 +23,32 @@ if __name__ == "__main__":
 
     # Sample rate and desired cutoff frequencies (in Hz).
     order = 6
-    fs = 5000.0
-    lowcut = 600.0
+    fs = 1000.0
     nyq = 0.5 * fs
-    low = lowcut / nyq
+    low = 0.1
+    lowcut = low * nyq
+
+    print("Filter paramters:")
+    print("- order = ", order)
+    print("- fs = ", fs)
+    print("- nyq = ", nyq)
+    print("- low = ", low)
+    print("- lowcut = ", lowcut)
 
     my_filter.init(1, 1.0/fs, low, order)
 
     my_filter.update(low, order)
 
+    print("- numerator = ", my_filter.numerator)
+    print("- denominator = ", my_filter.denominator)
+
     # Filter a noisy signal.
-    T = 0.05
+    T = 0.2
     nsamples = int(T * fs)
     t = np.linspace(0, T, nsamples, endpoint=False)
-    a = [0.1, 0.01, 0.02, 0.03]
+    a = [0.1, 0.005, 0.004, 0.003]
     
-    f0 = 600.0
+    f0 = 50.0
     x = a[0] * np.sin(2 * np.pi * 1.2 * np.sqrt(t))
     x += a[1] * np.cos(2 * np.pi * 312 * t + 0.1)
     x += a[2] * np.cos(2 * np.pi * f0 * t + .11)
@@ -56,7 +66,7 @@ if __name__ == "__main__":
 
     plt.plot(t, y, label='Filtered signal (%g Hz)' % f0)
     plt.xlabel('time (seconds)')
-    plt.hlines([-np.sum(a), np.sum(a)], 0, T, linestyles='--')
+    # plt.hlines([-np.sum(a), np.sum(a)], 0, T, linestyles='--')
     plt.grid(True)
     plt.axis('tight')
     plt.legend(loc='upper left')

--- a/demos/demo_filter.py
+++ b/demos/demo_filter.py
@@ -19,7 +19,7 @@ from dg_tools.filter import ButterWorthFilter
 
 if __name__ == "__main__":
 
-    my_filter = ButterWorthFilter('butterworth_filter')
+    my_filter = ButterWorthFilter("butterworth_filter")
 
     # Sample rate and desired cutoff frequencies (in Hz).
     order = 6
@@ -35,7 +35,7 @@ if __name__ == "__main__":
     print("- low = ", low)
     print("- lowcut = ", lowcut)
 
-    my_filter.init(1, 1.0/fs, low, order)
+    my_filter.init(1, 1.0 / fs, low, order)
 
     my_filter.update(low, order)
 
@@ -47,16 +47,16 @@ if __name__ == "__main__":
     nsamples = int(T * fs)
     t = np.linspace(0, T, nsamples, endpoint=False)
     a = [0.1, 0.005, 0.004, 0.003]
-    
+
     f0 = 50.0
     x = a[0] * np.sin(2 * np.pi * 1.2 * np.sqrt(t))
     x += a[1] * np.cos(2 * np.pi * 312 * t + 0.1)
-    x += a[2] * np.cos(2 * np.pi * f0 * t + .11)
+    x += a[2] * np.cos(2 * np.pi * f0 * t + 0.11)
     x += a[3] * np.cos(2 * np.pi * 2000 * t)
 
     plt.figure(1)
     plt.clf()
-    plt.plot(t, x, label='Noisy signal')
+    plt.plot(t, x, label="Noisy signal")
 
     y = []
     for i in range(x.size):
@@ -64,11 +64,11 @@ if __name__ == "__main__":
         my_filter.sout.recompute(i)
         y += [my_filter.sout.value]
 
-    plt.plot(t, y, label='Filtered signal (%g Hz)' % f0)
-    plt.xlabel('time (seconds)')
+    plt.plot(t, y, label="Filtered signal (%g Hz)" % f0)
+    plt.xlabel("time (seconds)")
     # plt.hlines([-np.sum(a), np.sum(a)], 0, T, linestyles='--')
     plt.grid(True)
-    plt.axis('tight')
-    plt.legend(loc='upper left')
+    plt.axis("tight")
+    plt.legend(loc="upper left")
 
     plt.show()

--- a/demos/demo_traj_generator.py
+++ b/demos/demo_traj_generator.py
@@ -45,7 +45,6 @@ if __name__ == "__main__":
 
     nsamples = int(duration / time_period)
     t = np.linspace(0, duration, nsamples, endpoint=False)
-    
 
     des_pos = []
     des_vel = []
@@ -65,4 +64,3 @@ if __name__ == "__main__":
     plt.legend(loc="upper left")
 
     plt.show()
-

--- a/python/dg_tools/sliders.py
+++ b/python/dg_tools/sliders.py
@@ -16,20 +16,30 @@ from dynamic_graph.sot.core.math_small_entities import (
     Component_of_vector,
     Selec_of_vector,
     Multiply_double_vector,
-    Add_of_vector
+    Add_of_vector,
 )
-
-from dg_tools.filter import ButterWorthFilter
-
+from dynamic_graph.sot.core.filter_differentiator import FilterDifferentiator
 from dg_tools.utils import VectorSignal, DoubleSignal
+
 
 class Sliders(object):
     """
     This class filter the sliders signals from the hardware.
+
+    Filter paramters:
+    - order =  6
+    - fs =  1000.0
+    - nyq =  500.0
+    - low =  0.1
+    - lowcut =  50.0
+    - numerator =  [8.57655707e-06, 5.14593424e-05, 1.28648356e-04,
+                    1.71531141e-04, 1.28648356e-04, 5.14593424e-05,
+                    8.57655707e-06]
+    - denominator =  [1., -4.7871355, 9.64951773, -10.46907889,   6.44111188,
+                      -2.12903875,   0.29517243]
     """
 
-    def __init__(self, nb_sliders, prefix="", filter_size=400, control_time_step=0.001,
-                 percentage_nyquist_cutoff=0.1, filter_order=6):
+    def __init__(self, nb_sliders, prefix="", control_time_step=0.001):
         """
         Initialize the class by creating all the output signals
         """
@@ -38,18 +48,49 @@ class Sliders(object):
 
         self.nb_sliders = nb_sliders
         self.prefix = prefix
+        self.control_time_step = control_time_step
 
-        self.sliders_filtered = ButterWorthFilter(self.prefix + "_sliders_butter")
-        self.sliders_filtered.init(nb_sliders, control_time_step,
-            percentage_nyquist_cutoff, filter_order)
-        self.sin = self.sliders_filtered.sin
+        # Define the filter
+        self.numerator = np.array([
+            8.57655707e-06,
+            5.14593424e-05,
+            1.28648356e-04,
+            1.71531141e-04,
+            1.28648356e-04,
+            5.14593424e-05,
+            8.57655707e-06,
+        ])
+        self.denominator = np.array([
+            1.0,
+            -4.7871355,
+            9.64951773,
+            -10.46907889,
+            6.44111188,
+            -2.12903875,
+            0.29517243,
+        ])
+        self.sliders_filtered = FilterDifferentiator(
+            self.prefix + "_lowpass_filter"
+        )
+        self.sliders_filtered.init(
+            self.control_time_step,
+            self.nb_sliders,
+            self.numerator,
+            self.denominator,
+        )
+
+        #
+        # Input signal of the subgraph
+        #
+        self.sin = self.sliders_filtered.x
 
         #
         # Slider operations
         #
 
         for i, slider_letter in enumerate(
-                list(string.ascii_uppercase[:nb_sliders])):
+            list(string.ascii_uppercase[:nb_sliders])
+        ):
             # names
             slider_name = "slider_" + slider_letter
             slider_component = slider_name + "_component_of_vector_sout"
@@ -60,62 +101,79 @@ class Sliders(object):
 
             # Get the slider as a vector
             self.__dict__[slider_sel_vec] = Selec_of_vector(
-                self.prefix + slider_sel_vec)
+                self.prefix + slider_sel_vec
+            )
             self.__dict__[slider_sel_vec].selec(i, i + 1)
-            plug(self.sliders_filtered.sout,
-                 self.__dict__[slider_sel_vec].sin)
+            plug(
+                self.sliders_filtered.x_filtered,
+                self.__dict__[slider_sel_vec].sin,
+            )
 
             # offset the slider
             self.__dict__[slider_offset] = Add_of_vector(
-                self.prefix + slider_offset)
+                self.prefix + slider_offset
+            )
             self.__dict__[slider_offset].setSignalNumber(2)
 
             # sin1 - sin2
-            plug(self.__dict__[slider_sel_vec].sout,
-                 self.__dict__[slider_offset].sin(0))
+            plug(
+                self.__dict__[slider_sel_vec].sout,
+                self.__dict__[slider_offset].sin(0),
+            )
             self.__dict__[slider_offset].sin(1).value = np.array([0.0])
 
             # Scale the slider
             self.__dict__[slider_scale] = Multiply_double_vector(
-                self.prefix + slider_scale)
+                self.prefix + slider_scale
+            )
             self.__dict__[slider_scale].sin1.value = 1.0
-            plug(self.__dict__[slider_offset].sout,
-                 self.__dict__[slider_scale].sin2)
+            plug(
+                self.__dict__[slider_offset].sout,
+                self.__dict__[slider_scale].sin2,
+            )
 
             # Get the slider as a double
             self.__dict__[slider_component] = Component_of_vector(
-                self.prefix + slider_component)
+                self.prefix + slider_component
+            )
             self.__dict__[slider_component].setIndex(0)
-            plug(self.__dict__[slider_scale].sout,
-                 self.__dict__[slider_component].sin)
+            plug(
+                self.__dict__[slider_scale].sout,
+                self.__dict__[slider_component].sin,
+            )
 
             # Get the slider as a vector
             self.__dict__[slider_sel_vec_sout] = Selec_of_vector(
-                self.prefix + slider_sel_vec_sout)
+                self.prefix + slider_sel_vec_sout
+            )
             self.__dict__[slider_sel_vec_sout].selec(0, 1)
-            plug(self.__dict__[slider_scale].sout,
-                 self.__dict__[slider_sel_vec_sout].sin)
+            plug(
+                self.__dict__[slider_scale].sout,
+                self.__dict__[slider_sel_vec_sout].sin,
+            )
 
             # create some shortcut
             class Slider(object):
                 """
                 empty shell filled below
                 """
+
                 pass
+
             self.__dict__[slider_name] = Slider()
             self.__dict__[slider_name].double = self.__dict__[slider_component]
             self.__dict__[slider_name].vector = self.__dict__[slider_scale]
             self.__dict__[slider_letter] = self.__dict__[slider_component].sout
-            self.__dict__[slider_letter + "_vec"] = (
-                self.__dict__[slider_sel_vec_sout].sout
-            )
+            self.__dict__[slider_letter + "_vec"] = self.__dict__[
+                slider_sel_vec_sout
+            ].sout
 
     def set_scale_values(self, scale_values):
         assert len(scale_values) == self.nb_sliders
 
         for slider_letter, scale in zip(
-                list(string.ascii_uppercase[:self.nb_sliders]),
-                scale_values):
+            list(string.ascii_uppercase[: self.nb_sliders]), scale_values
+        ):
             # names
             slider_name = "slider_" + slider_letter
             slider_scale = slider_name + "_scale"
@@ -126,8 +184,8 @@ class Sliders(object):
         assert len(offset_values) == self.nb_sliders
 
         for slider_letter, offset in zip(
-                list(string.ascii_uppercase[:self.nb_sliders]),
-                offset_values):
+            list(string.ascii_uppercase[: self.nb_sliders]), offset_values
+        ):
             # names
             slider_name = "slider_" + slider_letter
             slider_offset = slider_name + "_offset"
@@ -141,7 +199,7 @@ class Sliders(object):
 
     def trace(self, robot):
         robot.add_trace(self.sliders_filtered.name, "x_filtered")
-        for slider_letter in list(string.ascii_uppercase[:self.nb_sliders]):
+        for slider_letter in list(string.ascii_uppercase[: self.nb_sliders]):
             # names
             slider_name = "slider_" + slider_letter
             slider_component = slider_name + "_Component_of_vector"


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

[//]: # "Description of what you did.  If it is more complex, consider to add a"
[//]: # "'Summary' section."

This remove the import from scipy in the silder.py file as it seems that the embedded python interpreter is not happy with it.

## How I Tested

[//]: # "Explain how you tested your changes"

I loaded the graph using the dynamic_graph_manager_demo.
To be tested on a robot...

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
