### PR TITLE
Simplify the convertion between XYZQuat and pinocchio.SE3 representat…

### DIFF
--- a/include/dg_tools/utils.hpp
+++ b/include/dg_tools/utils.hpp
@@ -1,0 +1,20 @@
+/**
+ * @file
+ * @license BSD 3-clause
+ * @copyright Copyright (c) 2021, New York University and Max Planck
+ * Gesellschaft
+ *
+ * @brief Utilities used accross this package.
+ */
+
+#pragma once
+
+#include <pinocchio/spatial/se3.hpp>
+
+namespace dg_tools
+{
+Eigen::VectorXd se3_to_xyzquat(const pinocchio::SE3& in);
+
+pinocchio::SE3 xyzquat_to_se3(Eigen::Ref<const Eigen::VectorXd> in);
+
+}  // namespace dg_tools

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,7 @@ set(cpp_source_files
   data/memory_replay.cpp
   operator.cpp
   create_world_frame.cpp
+  utils.cpp
 )
 
 add_library(${lib_name} SHARED ${cpp_source_files})

--- a/src/create_world_frame.cpp
+++ b/src/create_world_frame.cpp
@@ -103,6 +103,7 @@ dynamicgraph::Vector& CreateWorldFrame::output_callback(
         quaternion_.y() = offset_value(4);
         quaternion_.z() = offset_value(5);
         quaternion_.w() = offset_value(6);
+        quaternion_.normalize();
         rpy_ = pinocchio::rpy::matrixToRpy(quaternion_.toRotationMatrix());
         rpy_ = rpy_.array() * which_dofs_.tail<3>().array();
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,0 +1,58 @@
+/**
+ * @file
+ * @license BSD 3-clause
+ * @copyright Copyright (c) 2021, New York University and Max Planck
+ * Gesellschaft
+ *
+ * @brief Utilities used accross this package.
+ */
+
+#include <sstream>
+#include "dg_tools/utils.hpp"
+
+namespace dg_tools
+{
+Eigen::VectorXd se3_to_xyzquat(const pinocchio::SE3& in)
+{
+    Eigen::VectorXd out = Eigen::VectorXd::Zero(7);
+    // Extract position.
+    out.head<3>() = in.translation();
+    // Extract orientation.
+    Eigen::Quaterniond quaternion = Eigen::Quaterniond(in.rotation());
+    quaternion.normalize();
+    out(3) = quaternion.x();
+    out(4) = quaternion.y();
+    out(5) = quaternion.z();
+    out(6) = quaternion.w();
+    return out;
+}
+
+pinocchio::SE3 xyzquat_to_se3(Eigen::Ref<const Eigen::VectorXd> in)
+{
+    if(in.size() != 7)
+    {
+        std::ostringstream oss;
+        oss << "dg_tools::se3_to_xyzquat(): "
+            << "input size ("
+            << in.size()
+            << ") is wrong, must be 7.";
+        throw std::runtime_error(oss.str());
+    }
+
+    // create the output.
+    pinocchio::SE3 out;
+    
+    // extract the orientation.
+    pinocchio::SE3::Quaternion quat;
+    quat.x() = in(3);
+    quat.y() = in(4);
+    quat.z() = in(5);
+    quat.w() = in(6);
+    quat.normalize();
+    // convert to pinocchio::SE3
+    out.translation() = in.head<3>();
+    out.rotation() = quat.toRotationMatrix();
+    return out;
+}
+
+}  // namespace dg_tools


### PR DESCRIPTION
…ions

[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

[//]: # "Description of what you did.  If it is more complex, consider to add a"
[//]: # "'Summary' section."

Simplify the code between pinocchio.SE3 and Eigen::VectorXd (XYZQuat) representations.

## How I Tested

[//]: # "Explain how you tested your changes"

I ran the entity on my machine in simulation for the walk of Solo12.

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
